### PR TITLE
Fixes for large files and consistency with existing interface

### DIFF
--- a/Source/ByteStream.js
+++ b/Source/ByteStream.js
@@ -23,7 +23,7 @@ class ByteStream
 
 	readBytes(numberOfBytesToRead)
 	{
-		var returnValue = [];
+		var returnValue = new Array(numberOfBytesToRead);
 
 		for (var b = 0; b < numberOfBytesToRead; b++)
 		{

--- a/Source/TarFile.js
+++ b/Source/TarFile.js
@@ -91,6 +91,9 @@ class TarFile
 					(a, b) => a += String.fromCharCode(b),
 					""
 				);
+				//Drop all null terminating character
+				entryNext.header.fileName = entryNext.header.fileName.replace(/\0/g, "");
+				
 				entries.splice(i, 1);
 				i--;
 			}


### PR DESCRIPTION
- preallocate array size - had given problems loading large files
- clearing null-terminating characters (created by `tar`) that were on the long file names
   - provides a consistent file name format for long and short file names

This is a PR for the changes referenced in the original change [here](https://github.com/thiscouldbebetter/TarFileExplorer/issues/2#issuecomment-660354417)